### PR TITLE
Add release workflow for multi-arch image publish to GHCR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,41 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    name: Publish multi-arch image to GHCR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push multi-arch image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ghcr.io/mooneeb/amgi:${{ github.ref_name }}
+            ghcr.io/mooneeb/amgi:latest


### PR DESCRIPTION
## Summary

Adds `.github/workflows/release.yml`, a tag-triggered workflow that
builds a multi-architecture (linux/amd64 + linux/arm64) container
image from the existing `Dockerfile` and publishes it to GitHub
Container Registry at `ghcr.io/mooneeb/amgi`. Fires only on tag
pushes matching `v*`; does not run on regular pushes to `main`.

## Related issue (required)

Closes #2

## How this was tested

- YAML structure validated locally; workflow file is syntactically
  legal for GitHub's workflow parser.
- `go build ./...`, `go vet ./...`, and `go test -race -count=1 ./...`
  all pass locally. The changes are pure-YAML with no Go code
  touched, so these are trivially green — but verified, not assumed.
- End-to-end validation (actual multi-arch build + GHCR push) is
  gated on the first real tag push. The workflow is tag-triggered
  only, so this PR cannot run it. CI will still gate the PR via the
  existing `fmt + vet + build + test` workflow.

## Checklist

- [x] This PR links a GitHub issue (Closes #2)
- [x] `go build ./...` and `go vet ./...` both pass locally
- [x] `go test -race ./...` passes locally
- [x] Documentation updated if behavior changed — N/A for this PR;
      release-process documentation lands with the companion
      deployment manifests PR.
- [x] No secrets, personal config, or local state included in the diff
- [x] Commits have meaningful messages and are logically separate

## Notes for reviewers

Three design decisions worth eyeing:

1. **Tag-only trigger** (`on: push: tags: [v*]`). Separates releases
   from merges — images build only when `git tag && git push --tags`.
   No `:latest` churn on every `main` merge.
2. **Auth via auto-injected `GITHUB_TOKEN`** with `packages: write`.
   No PAT to store, no credential rotation.
3. **Simple tag set**: `:v<version>` + `:latest`. Not the full
   semver floating-tag scheme (`:1`, `:1.0`) — can extend later
   if users want the floating pattern.

Multi-arch is handled by `docker/setup-qemu-action` (arm64 emulation
on the amd64 runner) plus `docker/setup-buildx-action` (BuildKit's
multi-platform build engine). Expect ~3-5 minutes of runtime on
first real tag — arm64 under QEMU is the slow leg.