### PR TITLE
Add Docker Compose deployment + self-host documentation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,60 @@
+# AMGI — Environment variable template
+#
+# This is a TEMPLATE — committed to the repo as .env.example. To use:
+#
+#   1. cp .env.example .env
+#   2. Fill in the values required for YOUR deployment mode (see below).
+#   3. docker compose up -d
+#
+# Compose auto-loads `.env` from this directory at startup. The real
+# `.env` is gitignored — never commit it with real values.
+#
+# Conditional requirements — AMGI validates these at startup based on
+# your config.yaml mode settings:
+#
+#   Always required:           MARVIN_API_TOKEN
+#   Required if webhook mode:  GITHUB_WEBHOOK_SECRET
+#   Required if polling mode:  GITHUB_TOKEN
+#
+# Variables not needed for your mode can be left blank.
+
+# MARVIN_API_TOKEN (always required)
+#
+# Amazing Marvin API token. Used for every Marvin API call:
+# GET /api/categories, GET /api/labels, POST /api/addTask.
+#
+# How to obtain:
+#   Marvin → Strategies → API → "Show API credentials" → copy the
+#   "Your API token" value.
+MARVIN_API_TOKEN=
+
+# GITHUB_WEBHOOK_SECRET (required for webhook mode)
+#
+# HMAC-SHA256 key that GitHub signs webhook payloads with, and that
+# AMGI verifies against. Arbitrary high-entropy string. Generate one:
+#
+#   openssl rand -hex 32
+#
+# This value MUST match the "Secret" field in your GitHub webhook
+# configuration (Repo → Settings → Webhooks → Edit → Secret). A
+# mismatch means every delivery fails signature validation, AMGI
+# logs a warning, and no tasks are created.
+#
+# Leave blank for polling-only deployments.
+GITHUB_WEBHOOK_SECRET=
+
+# GITHUB_TOKEN (required for polling mode)
+#
+# GitHub Personal Access Token. Used only when one or more owners
+# in config.yaml have `mode: polling`.
+#
+# Required scopes:
+#   - `repo`         if you sync any private repositories (full scope)
+#   - `public_repo`  if you only sync public repositories (narrower)
+#
+# Create one:
+#   https://github.com/settings/tokens (classic) or
+#   https://github.com/settings/personal-access-tokens (fine-grained)
+#
+# Leave blank for webhook-only deployments.
+GITHUB_TOKEN=

--- a/README.md
+++ b/README.md
@@ -78,16 +78,18 @@ export AMGI_DB_PATH="/var/lib/amgi/amgi.db"
 
 ### Run with Docker
 
-```bash
-docker build -t amgi .
+For single-host self-hosting, use Docker Compose — see [`docs/deploy-docker.md`](docs/deploy-docker.md) for the full setup runbook.
 
+For a one-liner alternative (no compose file):
+
+```bash
 docker run --rm \
   -e GITHUB_TOKEN -e MARVIN_API_TOKEN -e GITHUB_WEBHOOK_SECRET \
   -v $(pwd)/config.yaml:/etc/amgi/config.yaml:ro \
   -v amgi-data:/var/lib/amgi \
   -e AMGI_DB_PATH=/var/lib/amgi/amgi.db \
   -p 8080:8080 \
-  amgi
+  ghcr.io/mooneeb/amgi:latest
 ```
 
 The webhook server listens on port 8080 by default; the `-p` flag maps it to your host. For polling-only deployments you can omit `-p`.

--- a/deploy/docker-compose.yaml
+++ b/deploy/docker-compose.yaml
@@ -1,0 +1,57 @@
+# AMGI — Docker Compose deployment
+#
+# Starter-quality manifest for single-host self-hosting. Review the
+# "Tuning for production" section of docs/deploy-docker.md before
+# relying on defaults — this file deliberately omits healthcheck,
+# resource limits, and TLS termination, all of which are
+# environment-specific decisions tracked as Post-1.0 work in
+# docs/Roadmap.md section 2.3.
+#
+# Prerequisites:
+#   - Docker Engine 20.10+ and Docker Compose v2 (the `docker compose`
+#     subcommand; compose v1's `docker-compose` binary is EOL).
+#   - A `config.yaml` in the same directory as this file
+#     (see examples/config.yaml for a starter).
+#   - A `.env` file with GITHUB_TOKEN, GITHUB_WEBHOOK_SECRET,
+#     MARVIN_API_TOKEN. Copy .env.example → .env and fill in values.
+
+services:
+  amgi:
+    image: ghcr.io/mooneeb/amgi:latest
+    container_name: amgi
+    restart: unless-stopped
+
+    # Webhook server port. Map only if your config.yaml enables
+    # webhook_server; polling-only deployments can delete this block.
+    # For production, put AMGI behind a reverse proxy with TLS —
+    # do NOT expose :8080 to the public internet directly.
+    ports:
+      - "8080:8080"
+
+    volumes:
+      # Config file — bind-mounted read-only. Edit config.yaml on the
+      # host and restart the container (`docker compose restart amgi`)
+      # to pick up changes.
+      - ./config.yaml:/etc/amgi/config.yaml:ro
+
+      # SQLite database — named volume (docker-managed). Survives
+      # `docker compose down`; removed explicitly via
+      # `docker volume rm <project>_amgi-data`. Named volumes avoid
+      # host-UID permission mismatches (the image runs as UID 65532
+      # via distroless/static-debian12:nonroot).
+      - amgi-data:/var/lib/amgi
+
+    # Container environment. Compose interpolates ${VAR} from the
+    # .env file in this directory (auto-loaded) before passing to
+    # the container. Path overrides are explicit here (duplicating
+    # the Dockerfile ENV defaults) so the compose file is
+    # self-documenting for operators.
+    environment:
+      GITHUB_TOKEN: ${GITHUB_TOKEN}
+      GITHUB_WEBHOOK_SECRET: ${GITHUB_WEBHOOK_SECRET}
+      MARVIN_API_TOKEN: ${MARVIN_API_TOKEN}
+      CONFIG_PATH: /etc/amgi/config.yaml
+      AMGI_DB_PATH: /var/lib/amgi/amgi.db
+
+volumes:
+  amgi-data:

--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -38,6 +38,9 @@ Work scoped for after the v1.0 release, grouped by theme.
 - **Schema migrations** — the SQLite file persists across deployments. Schema changes in a new AMGI release need migrations to run on startup. Planned shape: a `schema_version` table, embedded migration scripts (`001_initial.sql`, `002_add_column.sql`), in-order execution. Only needed once the schema actually changes.
 - **High availability** — today AMGI runs as a single replica (SQLite single-writer). Multiple replicas for failover would require a PostgreSQL backend option and shared-state coordination, with schema compatibility across backends.
 - **Multi-tenant webhook paths** — today AMGI uses a single webhook endpoint for all owners. A future option could allow per-owner paths (`/webhooks/acme`, `/webhooks/other-owner`) for isolation or routing. Most production deployments route by payload; this adds complexity and is deferred until a concrete need surfaces.
+- **Health/readiness endpoint** — AMGI has no `/healthz` or `/readyz` HTTP endpoint. Deployment manifests (compose, Kubernetes) can wire TCP probes on the webhook port today, but that's wrong for polling-only deployments (webhook server disabled). A dedicated endpoint would be mode-agnostic and support Kubernetes-style readiness + liveness semantics.
+- **Opinionated resource sizing** — deployment manifests ship as starter templates with no resource limits set. Publishing a sizing guide — benchmarked against realistic workloads (webhook QPS, polling interval × repo count) — is post-1.0 work. Until then, operators size empirically.
+- **Reverse-proxy / TLS reference manifests** — webhook deployments need TLS termination and HTTP routing in front of the AMGI container. Setup is environment-specific (Traefik, Caddy, nginx, Cloudflare Tunnel, etc.) and v1.0 leaves this to the operator. Shipping reference configurations (a docker-compose override for Traefik, a Kubernetes Ingress + cert-manager example) is post-1.0.
 
 ## 3. Explicitly out of scope
 
@@ -52,6 +55,9 @@ Positions AMGI has committed to, so users and contributors can calibrate expecta
 
 Current-release gaps, cross-referenced to the post-1.0 work that closes each:
 
-- **No Layer 3 semantic config validation** — invalid cross-field references (e.g., a `marvin_config_id` that points at no existing config) surface at runtime rather than startup. See [§ 2.1](#21-validation-completeness).
-- **No `amgi validate` CLI subcommand** — the validation library exists; the CLI wrapper does not. See [§ 2.1](#21-validation-completeness).
-- **Database rows are kept indefinitely** — no automatic retention or pruning of `github_artifacts`. A busy deployment will grow unbounded until the retention feature lands. See [§ 2.3](#23-operational-maturity).
+- **No Layer 3 semantic config validation** — invalid cross-field references (e.g., a `marvin_config_id` that points at no existing config) surface at runtime rather than startup. See [section 2.1](#21-validation-completeness).
+- **No `amgi validate` CLI subcommand** — the validation library exists; the CLI wrapper does not. See [section 2.1](#21-validation-completeness).
+- **Database rows are kept indefinitely** — no automatic retention or pruning of `github_artifacts`. A busy deployment will grow unbounded until the retention feature lands. See [section 2.3](#23-operational-maturity).
+- **No health/readiness HTTP endpoint** — TCP probes on the webhook port work for webhook-mode deployments only; polling-only deployments have no liveness signal beyond process existence. See [section 2.3](#23-operational-maturity).
+- **No published sizing guide** — deployment manifests ship as starter templates without resource limits; operators size empirically for v1.0. See [section 2.3](#23-operational-maturity).
+- **No shipped reverse-proxy / TLS reference manifests** — webhook deployments need an external reverse proxy or tunnel for TLS termination; configuration is left to the operator for v1.0. See [section 2.3](#23-operational-maturity).

--- a/docs/deploy-docker.md
+++ b/docs/deploy-docker.md
@@ -1,0 +1,268 @@
+# AMGI — Docker Compose Deployment
+
+Docker Compose is the simplest way to run AMGI on a single host — a home lab, a small VPS, or a developer laptop. This guide covers setup, verification, day-to-day operations, and common troubleshooting. For broader project context see the [README](../README.md); for configuration details see [configuration.md](configuration.md).
+
+## Prerequisites
+
+- **Docker Engine 20.10+ with Compose v2** — use the modern `docker compose` subcommand, not the legacy `docker-compose` binary (EOL since 2023). Verify with `docker compose version`.
+- **An Amazing Marvin account** with API access and at least one category to land tasks in. AMGI resolves Marvin names (category names, label names) to internal IDs at startup — the categories and labels referenced in your `config.yaml` must already exist in Marvin.
+- **GitHub access**, depending on your deployment mode:
+  - **Webhook mode**: a publicly-reachable URL with TLS where GitHub can POST events. Setup is environment-specific (reverse proxy, tunnel, etc.) and out of scope for this doc.
+  - **Polling mode**: a GitHub Personal Access Token with `repo` scope (private repos) or `public_repo` scope (public only).
+
+## Quickstart
+
+A 10-minute happy-path setup. Every step assumes your working directory is the one containing `docker-compose.yaml`.
+
+### 1. Get the manifests
+
+```bash
+# Clone the repository (simplest)
+git clone https://github.com/mooneeb/amgi.git
+cd amgi/deploy
+
+# Alternative — download just the two deployment files
+mkdir amgi && cd amgi
+curl -O https://raw.githubusercontent.com/mooneeb/amgi/main/deploy/docker-compose.yaml
+curl -O https://raw.githubusercontent.com/mooneeb/amgi/main/.env.example
+```
+
+### 2. Create `config.yaml`
+
+AMGI needs a config file describing which GitHub owners/repos to sync and which Marvin configs to use. Copy one of the starters from [`examples/`](../examples/) and adapt it:
+
+```bash
+cp ../examples/minimal.yaml config.yaml
+# Open config.yaml in your editor and adapt it to your GitHub
+# owners/repos and Marvin configs.
+```
+
+**This file must exist before you launch.** The compose file bind-mounts `./config.yaml` into the container; if the file is missing when `docker compose up` runs, Docker creates an empty *directory* at that path and AMGI fails on read.
+
+See [`docs/configuration.md`](configuration.md) for the full schema.
+
+### 3. Create `.env`
+
+```bash
+cp .env.example .env
+# Open .env in your editor and fill in the values your mode requires.
+```
+
+The comments in `.env.example` document each variable, where to obtain it, and which mode needs it.
+
+### 4. Launch
+
+```bash
+docker compose up -d
+```
+
+The `-d` flag detaches — the container runs in the background.
+
+### 5. Watch for readiness
+
+```bash
+docker compose logs -f amgi
+```
+
+You should see JSON log lines like:
+
+```json
+{"level":"INFO","msg":"config loaded successfully"}
+{"level":"INFO","msg":"marvin client initialized (categories + labels cached; config references validated)"}
+{"level":"INFO","msg":"starting webhook server","path":"/webhooks/github","port":8080}
+{"level":"INFO","msg":"polled successfully","owner":"...","repo":"...","issue count":0,"pull request count":0}
+```
+
+Once you see `marvin client initialized` and whichever mode-specific readiness signal applies (`starting webhook server` for webhook mode, `polled successfully` for polling mode), AMGI is up. Exit the tail with Ctrl+C — the container keeps running.
+
+## Configuration
+
+### `config.yaml`
+
+AMGI's behavior is driven entirely by `config.yaml`. It defines which GitHub owners/repos to sync, which Marvin config (list + labels + task template) each owner maps to, and per-deployment options like polling intervals.
+
+- **Full schema reference:** [`docs/configuration.md`](configuration.md).
+- **Starter configs:** [`examples/`](../examples/) has persona-based starters.
+- **Pick-up semantics:** AMGI reads `config.yaml` once at startup. Edit the file, then `docker compose restart amgi` to apply changes.
+
+### Environment variables
+
+Secrets and path overrides are passed to the container via environment variables, loaded from the `.env` file in the working directory. Compose auto-loads `.env` before the container starts and interpolates `${VAR}` references in the compose file.
+
+See [`.env.example`](../.env.example) for each variable's purpose, format, and source.
+
+## Verifying the deployment
+
+### Expected startup log sequence
+
+A clean startup emits JSON logs in roughly this order:
+
+```json
+{"level":"INFO","msg":"config loaded successfully"}
+{"level":"INFO","msg":"store created successfully"}
+{"level":"INFO","msg":"marvin client created successfully"}
+{"level":"INFO","msg":"marvin client initialized (categories + labels cached; config references validated)"}
+{"level":"INFO","msg":"processor created successfully"}
+{"level":"INFO","msg":"resolved retry sweep interval","interval":300000000000,"source":"default"}
+{"level":"INFO","msg":"starting webhook server","path":"/webhooks/github","port":8080}
+{"level":"INFO","msg":"resolved polling interval","owner":"...","interval":60000000000,"source":"config"}
+```
+
+Notable lines:
+
+- **`marvin client initialized`** — AMGI has successfully authenticated to Marvin and resolved every `list_name` / `label_names` in your config to real Marvin IDs. If this line is missing, check `MARVIN_API_TOKEN` and confirm every name in config.yaml exists as a category/label in Marvin.
+- **`starting webhook server`** — the HTTP server is bound and listening on port 8080. Missing means either no owner has `mode: webhook` configured or the server failed to bind (port collision?).
+- **`polled successfully`** — polling is active for at least one owner.
+
+### Checking Marvin
+
+For each real GitHub activity you expect to sync:
+
+1. Trigger the activity (create an issue, open a PR).
+2. In webhook mode a task appears in Marvin within ~1-2 seconds. In polling mode, within one polling interval (default 60 seconds).
+3. Verify the task lands in the correct Marvin category (per your config's `list_name`), with the correct labels attached.
+4. Verify the task's title matches your `title_template` from config.yaml.
+
+### Checking GitHub (webhook mode)
+
+GitHub exposes a "Recent Deliveries" panel per webhook:
+
+1. Navigate: Repo → Settings → Webhooks → (your AMGI webhook) → Recent Deliveries.
+2. Each delivery shows a green ✓ (AMGI responded 2xx) or red ✗ (AMGI responded 4xx/5xx or the request timed out).
+3. Click any delivery to inspect the full request body, the response body, and the response latency.
+
+Green checks with 2xx responses confirm AMGI received and processed the webhook. Red X'es need diagnosis — see Troubleshooting.
+
+## Operations
+
+### Viewing logs
+
+```bash
+docker compose logs amgi              # all logs since the container started
+docker compose logs -f amgi           # stream new logs as they arrive
+docker compose logs --tail 100 amgi   # last 100 lines
+docker compose logs --since 10m amgi  # last 10 minutes
+```
+
+Logs are JSON-formatted for compatibility with log aggregators (Loki, CloudWatch, Datadog). Pipe through `jq` for readable output:
+
+```bash
+docker compose logs -f amgi | jq -r '. | "\(.time) [\(.level)] \(.msg)"'
+```
+
+### Restarting the service
+
+After editing `config.yaml`:
+
+```bash
+docker compose restart amgi
+```
+
+AMGI reads config at startup only — a restart is how it picks up changes. The SQLite state (idempotency records, polling cursors) is preserved in the named volume across restarts.
+
+### Updating to a new image version
+
+```bash
+docker compose pull amgi   # download the newest image per the tag in compose
+docker compose up -d       # recreate the container with the new image
+```
+
+The default image reference is `ghcr.io/mooneeb/amgi:latest`, which floats to the newest release. To pin a specific version:
+
+```yaml
+services:
+  amgi:
+    image: ghcr.io/mooneeb/amgi:v1.0.0   # pinned
+```
+
+### Stopping and removing
+
+```bash
+docker compose stop amgi   # stop the container, keep state
+docker compose down        # stop + remove container and network
+docker compose down -v     # also remove the named volume (ERASES SQLite state)
+```
+
+The `-v` flag is destructive — it deletes the idempotency database and polling cursors. Next startup behaves like a fresh install (AMGI does not backfill historical GitHub items — see [configuration.md](configuration.md) for cursor semantics).
+
+## Troubleshooting
+
+### Container exits immediately with a config-validation error
+
+Symptom: `docker compose ps` shows the amgi container as `Exited (1)`; logs contain an error like:
+
+```
+"failed to parse and validate config: schema validation failed\nmap[...polling_interval_seconds/minimum:30 should be at least 60 ...]"
+```
+
+The error path (`/github/owners/1/polling_interval_seconds/minimum`) is a JSON Schema breadcrumb pointing at the exact field that violates the schema — in this example, `github.owners[1].polling_interval_seconds` is below the 60-second minimum.
+
+Fix the config and relaunch with `docker compose up -d`.
+
+### `MARVIN_API_TOKEN is not set` on startup
+
+Exit with a log line like:
+
+```
+"MARVIN_API_TOKEN is not set"
+```
+
+Causes, in descending likelihood:
+
+1. `.env` doesn't exist, or isn't in the same directory as `docker-compose.yaml`. Compose only auto-loads `.env` from its working directory.
+2. `.env` exists but `MARVIN_API_TOKEN=...` is missing or blank.
+3. The `.env` line has trailing whitespace or quoting that breaks the value.
+
+Diagnose with:
+
+```bash
+docker compose config   # shows the fully-resolved compose config, including env
+```
+
+The variable value (or its absence) appears in the output. Same approach for `GITHUB_WEBHOOK_SECRET` and `GITHUB_TOKEN`.
+
+### Every webhook delivery shows as rejected (signature fail)
+
+Symptom: GitHub's Recent Deliveries panel shows red ✗ for every delivery; AMGI logs show:
+
+```json
+{"level":"WARN","msg":"webhook signature mismatch"}
+```
+
+Cause: the `GITHUB_WEBHOOK_SECRET` in `.env` does not match the Secret field in GitHub's webhook config. HMAC-SHA256 signatures only match when both sides hold the exact same secret.
+
+Fix:
+
+1. Regenerate the secret: `openssl rand -hex 32`.
+2. Update both `.env` (your side) and the GitHub webhook config (Repo → Settings → Webhooks → Edit → Secret).
+3. `docker compose restart amgi` to reload `.env`.
+
+### Tasks landing in the wrong Marvin category
+
+AMGI resolves each GitHub event to a Marvin config via the `(owner, repo)` tuple — not owner name alone. Each `(owner, repo)` pair must map to exactly one Marvin config in `config.yaml`.
+
+If you have multiple owner stanzas sharing the same owner name with different repos, AMGI's semantic validator enforces at startup that their repo sets are disjoint. If validation accepted your config but routing looks wrong, the stanza structure is likely ambiguous in practice — review how owners and their repositories are grouped.
+
+### GitHub polling returns zero items despite new activity
+
+Likely causes:
+
+1. **Cursor semantics** — AMGI polls with `since=<last-cursor>`. On first run it uses `since=now`, so items created before AMGI started are invisible (no historical backfill by design). Subsequent polls use the last poll's completion time.
+2. **Polling interval** — default is 60s. Activity created right after a poll completes waits for the next tick.
+3. **Wrong PAT scope** — syncing private repos with a `public_repo`-only token returns empty results for private repos silently. Check token scopes.
+
+### Marvin's daily API budget exhausted
+
+Symptom:
+
+```json
+{"level":"WARN","msg":"daily budget exceeded","resets_at":"..."}
+```
+
+Marvin has a documented 1440/day `addTask` cap. AMGI enforces it with a fixed-window counter that resets at UTC midnight.
+
+To avoid hitting the ceiling:
+
+- Check polling intervals — aggressive polling across many repos multiplies API calls.
+- Check filter scope — if every event creates a task, bursts of activity drain the budget. Consider action allowlists or label-based filters in `config.yaml`.
+- Review failed-task retries — transient failures retry on a configurable interval; persistent failures can compound budget usage.

--- a/internal/config/resolve/resolve.go
+++ b/internal/config/resolve/resolve.go
@@ -109,7 +109,7 @@ func ResolveActions(
 // ResolveFilters walks the repo → owner → global hierarchy and returns the
 // first non-nil *config.Filters it finds, or nil if no level has filters. A
 // nil return means "no filters configured; match all events" per the
-// architecture (see docs/architecture.md §Filter engine).
+// architecture (see docs/architecture.md, section "Filter engine").
 func ResolveFilters(
 	config *config.Config,
 	owner *config.Owner,


### PR DESCRIPTION
## Summary

Adds Docker Compose deployment (`deploy/docker-compose.yaml`, `.env.example`) and a self-host runbook (`docs/deploy-docker.md`). Updates `README.md` to point at the new docs. Adds three Post-1.0 items to `docs/Roadmap.md` section 2.3. Sweeps silcrow (§) from all tracked files.

## Related issue (required)

Closes #4

## How this was tested

- `go build ./...`, `go vet ./...`, `go test -race -count=1 ./...` all pass locally.
- `docker-compose.yaml` and `.env.example` hand-reviewed against `cmd/amgi/main.go` startup checks.
- End-to-end validation (`docker compose up -d` against a real image) is gated on v1.0 being tagged.

## Checklist

- [x] This PR links a GitHub issue (Closes #4)
- [x] `go build ./...` and `go vet ./...` both pass locally
- [x] `go test -race ./...` passes locally
- [x] Documentation updated if behavior changed — this PR IS the documentation
- [x] No secrets, personal config, or local state included in the diff
- [x] Commits have meaningful messages and are logically separate

## Notes for reviewers

The compose manifest is deliberately starter-quality — no healthcheck, no resource limits, no TLS. Each omission has an inline comment pointing to the Roadmap item tracking it. Do not add these in review.