### PR TITLE
Fix Docker Compose volume permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,15 @@ RUN CGO_ENABLED=0 GOOS=linux go build \
     -o /amgi \
     ./cmd/amgi
 
+# Pre-create an empty data directory in the builder stage so it can be
+# copied into the runtime image with the correct ownership. Docker's
+# volume initialization copies the IMAGE's path metadata into freshly-
+# mounted named volumes — without this, fresh volumes default to
+# root:root ownership and AMGI (UID 65532) cannot write its SQLite DB.
+# Distroless has no shell or `chown`, so the directory must be
+# prepared here in the builder stage.
+RUN mkdir -p /opt/amgi-data
+
 # ── Stage 2: runtime ──────────────────────────────────────────────
 # distroless/static = minimal base with CA certs + /etc/passwd + /etc/group.
 # No shell, no package manager, no extras. ~2MB.
@@ -32,6 +41,12 @@ FROM gcr.io/distroless/static-debian12:nonroot
 
 # Copy just the binary from the builder stage.
 COPY --from=builder /amgi /amgi
+
+# Copy the prepared data directory into the runtime image with
+# UID:GID 65532:65532 ownership. Fresh named volumes mounted at this
+# path will inherit this ownership, allowing the nonroot container
+# user to write its SQLite database without operator intervention.
+COPY --from=builder --chown=65532:65532 /opt/amgi-data /var/lib/amgi
 
 # Default Paths. Can be overridden at runtime with -e.
 ENV CONFIG_PATH=/etc/amgi/config.yaml

--- a/internal/processor/processor.go
+++ b/internal/processor/processor.go
@@ -60,7 +60,8 @@ func (p *processor) Process(
 		}
 		p.logger.Info("task created",
 			"owner", owner.Name, "repo", repo.Name,
-			"number", e.Number, "type", e.Type)
+			"number", e.Number, "type", e.Type,
+			"mode", owner.Mode)
 		return nil
 	}
 


### PR DESCRIPTION
## Summary

Two changes:

- Pre-create `/var/lib/amgi` in the runtime image with UID:GID 65532:65532 ownership so freshly-mounted Docker named volumes inherit writable permissions for the nonroot container user. Resolves a `SQLITE_CANTOPEN` crash loop on Docker Compose deployments using a fresh named volume.
- Add a `mode` field to the `task created` log line so operators can identify which path (webhook vs polling) created each task without correlating against surrounding context.

## Related issue (required)

Closes #11

## How this was tested

- `go build ./...`, `go vet ./...`, `go test -race -count=1 ./...` all pass locally.
- `docker build` produces an image with `/var/lib/amgi/` pre-owned by 65532:65532; smoke test against a fresh named volume confirms `store created successfully` (the previously-failing path).
- Full E2E with the same smoke configuration as v1.0.0 verification: Docker Compose and Kubernetes both create polling and webhook tasks correctly with the patched image.

## Checklist

- [x] This PR links a GitHub issue (Closes #11)
- [x] `go build ./...` and `go vet ./...` both pass locally
- [x] `go test -race ./...` passes locally
- [x] Documentation updated if behavior changed — no operator-facing change (manifests unchanged; fix is transparent)
- [x] No secrets, personal config, or local state included in the diff
- [x] Commits have meaningful messages and are logically separate